### PR TITLE
Leverage `__MODULE__` instead of `@struct`

### DIFF
--- a/lib/sntp/socket.ex
+++ b/lib/sntp/socket.ex
@@ -34,7 +34,7 @@ defmodule SNTP.Socket do
   @spec new(Enumerable.t()) :: t()
   def new(opts \\ []) do
     opts = validate_opts(opts)
-    @struct
+    __MODULE__
     |> Kernel.struct(opts)
     |> open()
   end

--- a/lib/sntp/timestamp.ex
+++ b/lib/sntp/timestamp.ex
@@ -77,7 +77,7 @@ defmodule SNTP.Timestamp do
             sent_locally:        sent_at,
             received_locally:    received_at]
 
-    @struct
+    __MODULE__
     |> Kernel.struct(opts)
     |> validate()
     |> calc_roundtrip()


### PR DESCRIPTION
This PR closes #1, by leveraging `__MODULE__` that will call: `__MODULE__.__struct_/1` to retrieve the compiled `@struct` or `@__struct__` module attribute across Elixir versions.